### PR TITLE
Add "binary" option to open() to avoid UnicodeDecodeError in Python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     description=('An application that generates RSS feeds for podcast '
                  'episodes from local audio files and, optionally, '
                  'exposes both via a built-in web server'),
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst', 'rb').read(),
     url='https://github.com/jkbrzt/podcats',
     download_url='https://github.com/jkbrzt/podcats',
     author='Jakub Roztocil',


### PR DESCRIPTION
setup.py does not work on Python3 because README.rst contains non-ascii char 'č'.

```
$ python -V
Python 3.6.0 :: Continuum Analytics, Inc.
$ python setup.py
Traceback (most recent call last):
  File "setup.py", line 10, in <module>
    long_description=open('README.rst').read(),
  File "/Users/momo/.anyenv/envs/pyenv/versions/anaconda3-4.1.1/envs/podcats36/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc4 in position 642: ordinal not in range(128)
```

this patch fixes this problem.

see http://stackoverflow.com/questions/10971033/backporting-python-3-openencoding-utf-8-to-python-2