### PR TITLE
Fix Issue #28:  mutagen.mp3.HeaderNotFoundError: can't sync to MPEG frame

### DIFF
--- a/podcats/__init__.py
+++ b/podcats/__init__.py
@@ -7,6 +7,7 @@ a built-in web server so that they can be imported into iTunes
 or another podcast client.
 
 """
+import datetime
 import os
 import re
 import time
@@ -93,6 +94,10 @@ class Episode(object):
         filename = os.path.basename(self.filename)
         directory = os.path.split(os.path.dirname(self.filename))[-1]
         template = jinja2_env.get_template('episode.html')
+        try:
+            date = formatdate(self.date)
+        except ValueError:
+            date = datetime.datetime.now(tz=datetime.timezone.utc)
 
         return template.render(
             title=escape(self.title),
@@ -101,7 +106,7 @@ class Episode(object):
             directory=directory,
             mimetype=self.mimetype,
             length=humanize.naturalsize(self.length),
-            date=formatdate(self.date),
+            date=date,
             image_url=self.image,
         )
 

--- a/podcats/__init__.py
+++ b/podcats/__init__.py
@@ -26,6 +26,7 @@ except ImportError:
 import mutagen
 import humanize
 from mutagen.id3 import ID3
+from mutagen.mp3 import HeaderNotFoundError
 from flask import Flask, Response
 # noinspection PyPackageRequirements
 from jinja2 import Environment, FileSystemLoader
@@ -52,7 +53,12 @@ class Episode(object):
         self.relative_dir = relative_dir
         self.root_url = root_url
         self.length = os.path.getsize(filename)
-        self.tags = mutagen.File(self.filename, easy=True)
+
+        try:
+            self.tags = mutagen.File(self.filename, easy=True)
+        except HeaderNotFoundError:
+            self.tags = {}
+
         try:
             self.id3 = ID3(self.filename)
         except Exception:

--- a/podcats/__init__.py
+++ b/podcats/__init__.py
@@ -121,7 +121,7 @@ class Episode(object):
         fn = os.path.basename(filepath)
         path = STATIC_PATH + '/' + self.relative_dir + '/' + fn
         path = re.sub(r'//', '/', path)
-        url = self.root_url + pathname2url(path)
+        url = self.root_url + quote(path, errors="surrogateescape")
         return url
 
     @property
@@ -236,7 +236,7 @@ class Channel(object):
             description=self.description,
             link=escape(self.link),
             items=u''.join(episode.as_html() for episode in sorted(self)),
-        ).strip()
+        ).strip().encode("utf-8", "surrogateescape")
 
 
 def serve(channel):


### PR DESCRIPTION
A fix for Issue #28 and a bunch of other Unicode encoding related issues and zero year values. So making the parsing more robust in general against Unicode input in python3.