### PR TITLE
Cleanup EOL Python versions to fix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12]
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12]
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - run: pip install .

--- a/podcats/__init__.py
+++ b/podcats/__init__.py
@@ -19,13 +19,6 @@ from os import path
 from urllib.parse import quote
 from xml.sax.saxutils import escape, quoteattr
 
-try:
-    from urllib.request import pathname2url
-except ImportError:
-    # For python 2
-    # noinspection PyUnresolvedReferences
-    from urllib import pathname2url
-
 import mutagen
 import humanize
 from mutagen.id3 import ID3

--- a/podcats/__init__.py
+++ b/podcats/__init__.py
@@ -56,7 +56,9 @@ class Episode(object):
             self.tags = mutagen.File(self.filename, easy=True) or {}
         except HeaderNotFoundError as err:
             self.tags = {}
-            logger.warning("Could not load tags of file {filename} due to: {err!r}".format(filename=self.filename, err=err))
+            logger.warning(
+                "Could not load tags of file {filename} due to: {err!r}".format(filename=self.filename, err=err)
+            )
 
         try:
             self.id3 = ID3(self.filename)
@@ -117,9 +119,9 @@ class Episode(object):
 
     def _to_url(self, filepath):
         fn = os.path.basename(filepath)
-        path = STATIC_PATH + '/' + self.relative_dir + '/' + fn
-        path = re.sub(r'//', '/', path)
-        url = self.root_url + quote(path, errors="surrogateescape")
+        path_ = STATIC_PATH + '/' + self.relative_dir + '/' + fn
+        path_ = re.sub(r'//', '/', path_)
+        url = self.root_url + quote(path_, errors="surrogateescape")
         return url
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,13 @@ def _get_long_description():
 
 setup(
     name='podcats',
-    version='0.6.3',
+    version='0.7.0',
     description=('An application that generates RSS feeds for podcast '
                  'episodes from local audio files and, optionally, '
                  'exposes both via a built-in web server'),
     long_description=_get_long_description(),
-    url='https://github.com/jakubroztocil/podcats',
-    download_url='https://github.com/jakubroztocil/podcats',
+    url='https://github.com/jkbrzt/podcats',
+    download_url='https://github.com/jkbrzt/podcats',
     author='Jakub Roztocil',
     author_email='jakub@subtleapps.com',
     license='BSD',
@@ -37,8 +37,12 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Environment :: Console',
         'Intended Audience :: End Users/Desktop',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
Python 2.7, 3.5 and 3.6 not supported by ubuntu-latest anymore. Those versions and python 3.7 are EOL. Should we drop 3.7 as well?