### PR TITLE
feat: add pyproject.toml for uv compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "podcats"
+version = "0.7.0"
+description = "An application that generates RSS feeds for podcast episodes from local audio files and, optionally, exposes both via a built-in web server"
+readme = "README.rst"
+authors = [
+    {name = "Jakub Roztocil", email = "jakub@subtleapps.com"}
+]
+license = {text = "BSD"}
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: BSD License",
+    "Topic :: Multimedia :: Sound/Audio",
+]
+requires-python = ">=3.7"
+dependencies = [
+    "Flask>=0.9",
+    "mutagen>=1.20",
+    "humanize>=0.5.1",
+]
+
+[project.urls]
+Homepage = "https://github.com/jkbrzt/podcats"
+Download = "https://github.com/jkbrzt/podcats"
+
+[project.scripts]
+podcats = "podcats:main"
+
+[tool.setuptools]
+packages = ["podcats"]
+include-package-data = true


### PR DESCRIPTION
Add pyproject.toml configuration file to enable modern Python packaging and make the project compatible with uv package manager while maintaining all existing metadata and dependencies from setup.py.